### PR TITLE
Rename pathName to baseHref; remove trailing slash from host URL

### DIFF
--- a/builders-test-app/skyuxconfig.json
+++ b/builders-test-app/skyuxconfig.json
@@ -1,7 +1,4 @@
 {
   "$schema": "./node_modules/@skyux-sdk/angular-builders/skyuxconfig-schema.json",
-  "codeCoverageThreshold": "strict",
-  "host": {
-    "url": "https://localhost:5234"
-  }
+  "codeCoverageThreshold": "strict"
 }

--- a/builders-test-app/skyuxconfig.json
+++ b/builders-test-app/skyuxconfig.json
@@ -1,21 +1,7 @@
 {
   "$schema": "./node_modules/@skyux-sdk/angular-builders/skyuxconfig-schema.json",
-  "app":{
-    "externals": {
-      "js": {
-        "after": [
-          {
-            "url": "https://www.bing.com/maps/sdk/mapcontrol"
-          }
-        ]
-      }
-    }
-  },
   "codeCoverageThreshold": "strict",
   "host": {
-    "bbCheckout": {
-      "version": "2"
-    },
-    "url": "https://app.blackbaud.com/"
+    "url": "https://localhost:5234"
   }
 }

--- a/src/builders/dev-server/dev-server-transforms.ts
+++ b/src/builders/dev-server/dev-server-transforms.ts
@@ -63,7 +63,7 @@ function getDevServerWepbackConfigTransformer(
       host: skyuxConfig.host,
       localUrl,
       open: options.skyuxOpen!,
-      pathName: context.target!.project!
+      baseHref: context.target!.project!
     });
 
     webpackConfig.plugins.push(

--- a/src/shared/skyux-config-utils.spec.ts
+++ b/src/shared/skyux-config-utils.spec.ts
@@ -30,23 +30,23 @@ describe('skyux config utils', () => {
     const util = mock.reRequire('./skyux-config-utils');
     expect(util.getSkyuxConfig()).toEqual({
       host: {
-        url: 'https://host.nxt.blackbaud.com/'
+        url: 'https://host.nxt.blackbaud.com'
       }
     });
   });
 
-  it('should add trailing slash to host url', () => {
+  it('should throw error if host URL contains trailing slash', () => {
     mockSkyuxConfig = {
-      host: {
-        url: 'https://foo.blackbaud.com'
-      }
-    };
-    const util = mock.reRequire('./skyux-config-utils');
-    expect(util.getSkyuxConfig()).toEqual({
       host: {
         url: 'https://foo.blackbaud.com/'
       }
-    });
+    };
+    const util = mock.reRequire('./skyux-config-utils');
+    expect(() => {
+      util.getSkyuxConfig();
+    }).toThrowError(
+      'The host URL must not end with a forward slash.'
+    );
   });
 
   it('should throw an error if skyuxconfig.json does not exist', () => {

--- a/src/shared/skyux-config-utils.spec.ts
+++ b/src/shared/skyux-config-utils.spec.ts
@@ -36,16 +36,18 @@ describe('skyux config utils', () => {
   });
 
   it('should throw error if host URL contains trailing slash', () => {
+    const invalidUrl = 'https://foo.blackbaud.com/';
+
     mockSkyuxConfig = {
       host: {
-        url: 'https://foo.blackbaud.com/'
+        url: invalidUrl
       }
     };
     const util = mock.reRequire('./skyux-config-utils');
     expect(() => {
       util.getSkyuxConfig();
     }).toThrowError(
-      'The host URL must not end with a forward slash.'
+      `[@skyux-sdk/angular-builders] The host URL must not end with a forward slash. You provided: "${invalidUrl}"`
     );
   });
 
@@ -53,7 +55,7 @@ describe('skyux config utils', () => {
     fileExists = false;
     const util = mock.reRequire('./skyux-config-utils');
     expect(util.getSkyuxConfig).toThrowError(
-      'A skyuxconfig.json file was not found at the project root.'
+      '[@skyux-sdk/angular-builders] A skyuxconfig.json file was not found at the project root. Did you run `ng add @skyux-sdk/angular-builders`?'
     );
   });
 });

--- a/src/shared/skyux-config-utils.ts
+++ b/src/shared/skyux-config-utils.ts
@@ -25,7 +25,7 @@ export function getSkyuxConfig(): SkyuxConfig {
   );
 
   const hostUrl = skyuxConfig.host.url;
-  if (hostUrl.charAt(hostUrl.length - 1) === '/') {
+  if (hostUrl.endsWith('/')) {
     throw new Error(
       `[@skyux-sdk/angular-builders] The host URL must not end with a forward slash. You provided: "${hostUrl}"`
     );

--- a/src/shared/skyux-config-utils.ts
+++ b/src/shared/skyux-config-utils.ts
@@ -6,13 +6,9 @@ import {
   SkyuxConfig
 } from './skyux-config';
 
-import {
-  ensureTrailingSlash
-} from './url-utils';
-
 const DEFAULTS: SkyuxConfig = {
   host: {
-    url: 'https://host.nxt.blackbaud.com/'
+    url: 'https://host.nxt.blackbaud.com'
   }
 };
 
@@ -26,7 +22,10 @@ export function getSkyuxConfig(): SkyuxConfig {
     fs.readJsonSync('skyuxconfig.json')
   );
 
-  skyuxConfig.host.url = ensureTrailingSlash(skyuxConfig.host.url);
+  const hostUrl = skyuxConfig.host.url;
+  if (hostUrl.charAt(hostUrl.length - 1) === '/') {
+    throw new Error('The host URL must not end with a forward slash.');
+  }
 
   return skyuxConfig;
 }

--- a/src/shared/skyux-config-utils.ts
+++ b/src/shared/skyux-config-utils.ts
@@ -14,7 +14,9 @@ const DEFAULTS: SkyuxConfig = {
 
 export function getSkyuxConfig(): SkyuxConfig {
   if (!fs.existsSync('skyuxconfig.json')) {
-    throw new Error('A skyuxconfig.json file was not found at the project root.');
+    throw new Error(
+      '[@skyux-sdk/angular-builders] A skyuxconfig.json file was not found at the project root. Did you run `ng add @skyux-sdk/angular-builders`?'
+    );
   }
 
   const skyuxConfig: SkyuxConfig = mergeWith(
@@ -24,7 +26,9 @@ export function getSkyuxConfig(): SkyuxConfig {
 
   const hostUrl = skyuxConfig.host.url;
   if (hostUrl.charAt(hostUrl.length - 1) === '/') {
-    throw new Error('The host URL must not end with a forward slash.');
+    throw new Error(
+      `[@skyux-sdk/angular-builders] The host URL must not end with a forward slash. You provided: "${hostUrl}"`
+    );
   }
 
   return skyuxConfig;

--- a/src/tools/webpack/plugins/open-host-url/create-host-url.spec.ts
+++ b/src/tools/webpack/plugins/open-host-url/create-host-url.spec.ts
@@ -15,12 +15,12 @@ import {
 describe('create host url', () => {
 
   let hostUrl: string;
-  let pathName: string;
+  let baseHref: string;
   let defaultHostConfig: SkyuxCreateHostUrlConfig;
 
   beforeEach(() => {
     hostUrl = 'https://host.nxt.blackbaud.com/';
-    pathName = 'my-project';
+    baseHref = 'my-project';
     defaultHostConfig = {
       localUrl: 'https://localhost:4200/',
       host: {
@@ -40,7 +40,7 @@ describe('create host url', () => {
   it('should open the SKY UX Host URL with Host config', () => {
     const { createHostUrl } = mock.reRequire('./create-host-url');
 
-    const actualUrl = createHostUrl(hostUrl, pathName, defaultHostConfig);
+    const actualUrl = createHostUrl(hostUrl, baseHref, defaultHostConfig);
 
     expect(actualUrl).toEqual(
       'https://host.nxt.blackbaud.com/my-project/?local=true&_cfg=eyJsb2NhbFVybCI6Imh0dHBzOi8vbG9jYWxob3N0OjQyMDAvIiwiaG9zdCI6eyJ1cmwiOiJodHRwczovL2hvc3Qubnh0LmJsYWNrYmF1ZC5jb20vIn19'
@@ -69,7 +69,7 @@ describe('create host url', () => {
 
     defaultHostConfig.host = hostConfig;
 
-    const actualUrl = createHostUrl(hostUrl, pathName, defaultHostConfig);
+    const actualUrl = createHostUrl(hostUrl, baseHref, defaultHostConfig);
 
     expect(decode(actualUrl).host).toEqual(hostConfig);
   });
@@ -91,7 +91,7 @@ describe('create host url', () => {
       }
     ];
 
-    const actualUrl = createHostUrl(hostUrl, pathName, defaultHostConfig);
+    const actualUrl = createHostUrl(hostUrl, baseHref, defaultHostConfig);
 
     expect(decode(actualUrl)).toEqual({
       localUrl: 'https://localhost:4200/',
@@ -126,7 +126,7 @@ describe('create host url', () => {
 
     defaultHostConfig.externals = externals;
 
-    const actualUrl = createHostUrl(hostUrl, pathName, defaultHostConfig);
+    const actualUrl = createHostUrl(hostUrl, baseHref, defaultHostConfig);
 
     expect(decode(actualUrl).externals).toEqual(externals);
   });
@@ -136,7 +136,7 @@ describe('create host url', () => {
 
     defaultHostConfig.scripts = [];
 
-    const actualUrl = createHostUrl(hostUrl, pathName, defaultHostConfig);
+    const actualUrl = createHostUrl(hostUrl, baseHref, defaultHostConfig);
 
     expect(decode(actualUrl)).toEqual({
       localUrl: 'https://localhost:4200/',

--- a/src/tools/webpack/plugins/open-host-url/create-host-url.ts
+++ b/src/tools/webpack/plugins/open-host-url/create-host-url.ts
@@ -1,4 +1,8 @@
 import {
+  ensureTrailingSlash
+} from '../../../../shared/url-utils';
+
+import {
   SkyuxCreateHostUrlConfig
 } from './create-host-url-config';
 
@@ -18,6 +22,8 @@ import {
   const configEncoded = encodeURIComponent(
     Buffer.from(JSON.stringify(config)).toString('base64')
   );
+
+  baseUrl = ensureTrailingSlash(baseUrl);
 
   return `${baseUrl}${baseHref}/?local=true&_cfg=${configEncoded}`;
 }

--- a/src/tools/webpack/plugins/open-host-url/create-host-url.ts
+++ b/src/tools/webpack/plugins/open-host-url/create-host-url.ts
@@ -5,12 +5,12 @@ import {
 /**
  * Creates the SKY UX Host URL.
  * @param baseUrl The base SKY UX Host URL, including the protocol.
- * @param pathName The URL-friendly pathname where the project will be served.
+ * @param baseHref The URL-friendly base HREF where the project will be served.
  * @param config Configuration that will be sent to the host server.
  */
  export function createHostUrl(
   baseUrl: string,
-  pathName: string,
+  baseHref: string,
   config: SkyuxCreateHostUrlConfig
 ): string {
   // We need to URL-encode the config so that characters such as '+'
@@ -19,5 +19,5 @@ import {
     Buffer.from(JSON.stringify(config)).toString('base64')
   );
 
-  return `${baseUrl}${pathName}/?local=true&_cfg=${configEncoded}`;
+  return `${baseUrl}${baseHref}/?local=true&_cfg=${configEncoded}`;
 }

--- a/src/tools/webpack/plugins/open-host-url/open-host-url-config.ts
+++ b/src/tools/webpack/plugins/open-host-url/open-host-url-config.ts
@@ -8,7 +8,7 @@ export interface SkyuxOpenHostUrlPluginConfig {
   /**
    * The unique base HREF of the SPA, e.g. 'my-spa'.
    */
-   baseHref: string;
+  baseHref: string;
 
   externals?: SkyuxConfigAppExternals;
 

--- a/src/tools/webpack/plugins/open-host-url/open-host-url-config.ts
+++ b/src/tools/webpack/plugins/open-host-url/open-host-url-config.ts
@@ -5,6 +5,11 @@ import {
 
 export interface SkyuxOpenHostUrlPluginConfig {
 
+  /**
+   * The unique base HREF of the SPA, e.g. 'my-spa'.
+   */
+   baseHref: string;
+
   externals?: SkyuxConfigAppExternals;
 
   host: SkyuxConfigHost;
@@ -18,10 +23,5 @@ export interface SkyuxOpenHostUrlPluginConfig {
    * Specifies if the URL should be opened in the default browser automatically.
    */
   open: boolean;
-
-  /**
-   * The unique pathname of the SPA, e.g. 'my-spa'.
-   */
-  pathName: string;
 
 }

--- a/src/tools/webpack/plugins/open-host-url/open-host-url.plugin.spec.ts
+++ b/src/tools/webpack/plugins/open-host-url/open-host-url.plugin.spec.ts
@@ -67,7 +67,7 @@ describe('open host url webpack plugin', () => {
         url: hostUrl
       },
       localUrl,
-      pathName: 'my-project'
+      baseHref: 'my-project'
     }, ...options});
 
     return plugin;

--- a/src/tools/webpack/plugins/open-host-url/open-host-url.plugin.ts
+++ b/src/tools/webpack/plugins/open-host-url/open-host-url.plugin.ts
@@ -64,7 +64,7 @@ export class SkyuxOpenHostUrlPlugin {
 
         const url = createHostUrl(
           this.config.host.url,
-          this.config.pathName,
+          this.config.baseHref,
           hostUrlConfig
         );
 


### PR DESCRIPTION
- Fix assumption about trailing slashes for Host URL.
- Open Host URL plugin: Rename `pathName` argument to `baseHref` to better communicate its purpose.