### PR TITLE
Fixed fallback variable for ES5 modules

### DIFF
--- a/src/tools/webpack/plugins/host-assets-fallback/host-assets-fallback.plugin.spec.ts
+++ b/src/tools/webpack/plugins/host-assets-fallback/host-assets-fallback.plugin.spec.ts
@@ -67,7 +67,7 @@ describe('host assets fallback webpack plugin', () => {
 
     const content = getAssetContent('main.js');
     expect(content).toEqual(
-      '[main content here]\nvar SKY_PAGES_READY_MAIN_JS = true;'
+      '[main content here]\nwindow.SKY_PAGES_READY_MAIN_JS = true;'
     );
   });
 

--- a/src/tools/webpack/plugins/host-assets-fallback/host-assets-fallback.plugin.ts
+++ b/src/tools/webpack/plugins/host-assets-fallback/host-assets-fallback.plugin.ts
@@ -22,7 +22,7 @@ export class SkyuxHostAssetsFallbackPlugin {
       modifyScriptContents(
         compilation,
         (content, file) =>
-          `${content}\nvar ${getFallbackTestVariable(file)} = true;`
+          `${content}\nwindow.${getFallbackTestVariable(file)} = true;`
       );
 
       // Add a fallback CSS rule to the bottom of each style sheet.


### PR DESCRIPTION
The Angular minimizer was optimizing out `var SKY_PAGES_READY_<BUNDLE_NAME>_JS = true` since it appeared inside a self-invoking function and was never used inside the function. Assigning it as a property on `window` fixes it.