### PR TITLE
Release 5.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.0-beta.2 (2021-11-17)
+
+- Fixed an issue when inlining external resources for components with Windows line endings. [#116](https://github.com/blackbaud/skyux-sdk-angular-builders/pull/116)
+
 # 5.0.0-beta.1 (2021-11-12)
 
 - Fixed the peer dependency version for `ng-packagr`. [#115](https://github.com/blackbaud/skyux-sdk-angular-builders/pull/115)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 5.0.0-beta.2 (2021-11-17)
+# 5.0.0-beta.2 (2021-11-18)
 
 - Fixed an issue when inlining external resources for components with Windows line endings. [#116](https://github.com/blackbaud/skyux-sdk-angular-builders/pull/116)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 5.0.0-beta.2 (2021-11-18)
 
-- Fixed an issue when inlining external resources for components with Windows line endings. [#116](https://github.com/blackbaud/skyux-sdk-angular-builders/pull/116)
+- Fixed a build issue for Windows. [#116](https://github.com/blackbaud/skyux-sdk-angular-builders/pull/116)
 
 # 5.0.0-beta.1 (2021-11-12)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux-sdk/angular-builders",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1913,9 +1913,9 @@
       }
     },
     "@types/jasmine": {
-      "version": "3.6.11",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.6.11.tgz",
-      "integrity": "sha512-S6pvzQDvMZHrkBz2Mcn/8Du7cpr76PlRJBAoHnSDNbulULsH5dp0Gns+WRyNX5LHejz/ljxK4/vIHK/caHt6SQ==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.8.2.tgz",
+      "integrity": "sha512-u5h7dqzy2XpXTzhOzSNQUQpKGFvROF8ElNX9P/TJvsHnTg/JvsAseVsGWQAQQldqanYaM+5kwxW909BBFAUYsg==",
       "dev": true
     },
     "@types/json-schema": {
@@ -11185,9 +11185,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux-sdk/angular-builders",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "description": "Schematics to run ng-packagr for Angular CLI library projects",
   "scripts": {
     "build": "npm run clean && npm run lint && tsc -p tsconfig.build.json",
@@ -37,7 +37,7 @@
     "@schematics/angular": "12.2.12",
     "@trivago/prettier-plugin-sort-imports": "3.1.0",
     "@types/fs-extra": "9.0.13",
-    "@types/jasmine": "3.6.11",
+    "@types/jasmine": "3.8.2",
     "@types/mock-require": "2.0.0",
     "@types/node": "14.14.45",
     "@typescript-eslint/eslint-plugin": "4.32.0",
@@ -53,6 +53,6 @@
     "rimraf": "3.0.2",
     "ts-node": "8.10.2",
     "tsc-watch": "4.5.0",
-    "typescript": "4.2.4"
+    "typescript": "4.3.5"
   }
 }


### PR DESCRIPTION
- Fixed an issue when inlining external resources for components with Windows line endings. [#116](https://github.com/blackbaud/skyux-sdk-angular-builders/pull/116)
